### PR TITLE
Update to 201808 release

### DIFF
--- a/iMX8Pkg/iMX8CommonDsc.inc
+++ b/iMX8Pkg/iMX8CommonDsc.inc
@@ -32,7 +32,6 @@
 
   BaseBinSecurityLib|MdePkg/Library/BaseBinSecurityLibNull/BaseBinSecurityLibNull.inf
   DeviceBootManagerLib|iMXPlatformPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.inf
-  Performance2Lib|MdePkg/Library/BasePerformance2LibNull/BasePerformance2LibNull.inf
   SecurityLockAuditLib|MdeModulePkg/Library/SecurityLockAuditLibNull/SecurityLockAuditLibNull.inf
 
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf


### PR DESCRIPTION
Remove non-existant BasePerformance2LibNull.inf reference from imx8 dsc file