### PR TITLE
Imx8m: eMMC and HashInstanceLib errors

### DIFF
--- a/iMX8Pkg/iMX8CommonDsc.inc
+++ b/iMX8Pkg/iMX8CommonDsc.inc
@@ -622,7 +622,8 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{ 0x5a, 0xf2, 0x6b, 0x28, 0xc3, 0xc2, 0x8c, 0x40, 0xb3, 0xb4, 0x25, 0xe6, 0x75, 0x8b, 0x73, 0x17 }
 
 [PcdsDynamicExDefault.common.DEFAULT]
-  gEfiSecurityPkgTokenSpaceGuid.PcdTcg2HashAlgorithmBitmap|0x0
+  # Tcg2Dxe registers Sha1 and Sha256
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcg2HashAlgorithmBitmap|0x3
 !endif
 
 ################################################################################


### PR DESCRIPTION
- Fix HashInstanceLib errors in debug console.  Set PcdTcg2HashAlgorithmBitmap to expected value.
- Fix eMMC high speed switch failures on iMX platform.  Wait on busy  signal for R1B and R5B uSDHC response types.