### PR TITLE
Roll back FTPM UUID to support Linux driver

### DIFF
--- a/iMX6Pkg/iMX6CommonFdf.inc
+++ b/iMX6Pkg/iMX6CommonFdf.inc
@@ -100,9 +100,9 @@
   }
 
 !if $(CONFIG_MEASURED_BOOT) == TRUE
-  # fTPM Service TA UUID in UEFI format: 53bab89c-b864-4d7e-acbc-33c07a9c1b8d
-  FILE FREEFORM = 53BAB89C-B864-4D7E-ACBC-33C07A9C1B8D {
-    SECTION RAW = Microsoft/OpteeClientPkg/Bin/fTpmTa/Arm/Test/53bab89c-b864-4d7e-acbc-33c07a9c1b8d.ta
+  # fTPM Service TA UUID in UEFI format: bc50d971-d4c9-42c4-82cb-343fb7f37896
+  FILE FREEFORM = BC50D971-D4C9-42C4-82CB-343FB7F37896 {
+    SECTION RAW = Microsoft/OpteeClientPkg/Bin/fTpmTa/Arm/Test/bc50d971-d4c9-42c4-82cb-343fb7f37896.ta
   }
 
   # AuthVar Service TA UUID in UEFI format: 2d57c0f7-bddf-48ea-832f-d84a1a219301

--- a/iMX7Pkg/iMX7CommonFdf.inc
+++ b/iMX7Pkg/iMX7CommonFdf.inc
@@ -189,9 +189,9 @@ READ_LOCK_STATUS   = TRUE
   }
 
 !if $(CONFIG_MEASURED_BOOT) == TRUE
-  # fTPM Service TA UUID in UEFI format: 53bab89c-b864-4d7e-acbc-33c07a9c1b8d
-  FILE FREEFORM = 53BAB89C-B864-4D7E-ACBC-33C07A9C1B8D {
-    SECTION RAW = Microsoft/OpteeClientPkg/Bin/fTpmTa/Arm/Test/53bab89c-b864-4d7e-acbc-33c07a9c1b8d.ta
+  # fTPM Service TA UUID in UEFI format: bc50d971-d4c9-42c4-82cb-343fb7f37896
+  FILE FREEFORM = BC50D971-D4C9-42C4-82CB-343FB7F37896 {
+    SECTION RAW = Microsoft/OpteeClientPkg/Bin/fTpmTa/Arm/Test/bc50d971-d4c9-42c4-82cb-343fb7f37896.ta
   }
 
   # AuthVar Service TA UUID in UEFI format: 2d57c0f7-bddf-48ea-832f-d84a1a219301

--- a/iMX8Pkg/iMX8CommonFdf.inc
+++ b/iMX8Pkg/iMX8CommonFdf.inc
@@ -128,9 +128,9 @@
   #
   INF SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
 
-  # fTPM Service TA UUID in UEFI format: 53bab89c-b864-4d7e-acbc-33c07a9c1b8d
-  FILE FREEFORM = 53BAB89C-B864-4D7E-ACBC-33C07A9C1B8D {
-    SECTION RAW = Microsoft/OpteeClientPkg/Bin/fTpmTa/Arm64/Test/53bab89c-b864-4d7e-acbc-33c07a9c1b8d.ta
+  # fTPM Service TA UUID in UEFI format: bc50d971-d4c9-42c4-82cb-343fb7f37896
+  FILE FREEFORM = BC50D971-D4C9-42C4-82CB-343FB7F37896 {
+    SECTION RAW = Microsoft/OpteeClientPkg/Bin/fTpmTa/Arm/Test/bc50d971-d4c9-42c4-82cb-343fb7f37896.ta
   }
 
   # AuthVar Service TA UUID in UEFI format: 2d57c0f7-bddf-48ea-832f-d84a1a219301


### PR DESCRIPTION
Roll back the UUID for the fTPM to support the Linux driver being upstreamed to mainline Linux. It uses the old UUID from before the storage changes.

This will need to be followed up by an update to mu_patform_nxp with the updated binaries.