### PR TITLE
iMX8 - minor fixes

### DIFF
--- a/iMX8Pkg/AcpiTables/Dbg2.aslc
+++ b/iMX8Pkg/AcpiTables/Dbg2.aslc
@@ -37,7 +37,7 @@
 #define KD_UART_BASE_ADDR                 UART3_BASE_ADDRESS // iMX8 0x30880000
 #define KD_UART_ACPI_PATH                 "\\_SB.UAR3"
 #elif FixedPcdGet32(PcdKdUartInstance) == 4
-#define KD_UART_BASE_ADDR                 UART4_BASE_ADDRESS // iMX8 0x30A80000
+#define KD_UART_BASE_ADDR                 UART4_BASE_ADDRESS // iMX8 0x30A60000
 #define KD_UART_ACPI_PATH                 "\\_SB.UAR4"
 #endif
 

--- a/iMX8Pkg/iMX8CommonDsc.inc
+++ b/iMX8Pkg/iMX8CommonDsc.inc
@@ -740,9 +740,11 @@
 #  ArmPkg/Drivers/GenericWatchdogDxe/GenericWatchdogDxe.inf
   MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf
 
+!if $(CONFIG_HEADLESS) != TRUE
   MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatformDxe.inf
   MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitterDxe.inf
   MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsoleDxe.inf
+!endif
   MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
   MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
 

--- a/iMX8Pkg/iMX8CommonFdf.inc
+++ b/iMX8Pkg/iMX8CommonFdf.inc
@@ -40,9 +40,11 @@
   #
   # Multiple Console IO support
   #
+!if $(CONFIG_HEADLESS) != TRUE
   INF MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatformDxe.inf
   INF MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitterDxe.inf
   INF MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsoleDxe.inf
+!endif
   INF MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
   INF MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
 


### PR DESCRIPTION
Minor fixes to imx8
- correct UART4 base address comment
- don't include graphics console for headless devices