### PR TITLE
imx8: undo retention idle state for iMX8M Mini

### DIFF
--- a/iMX8Pkg/AcpiTables/Dsdt-Platform.asl
+++ b/iMX8Pkg/AcpiTables/Dsdt-Platform.asl
@@ -42,7 +42,7 @@ Device (CPU0)
     Name (_LPI, Package () {
       0, // Revision
       0, // LevelID
-      2, // Count of packages
+      1, // Count of packages
 
       // Standby / WFI state.
       Package () {
@@ -63,27 +63,6 @@ Device (CPU0)
           Register (SystemMemory,0,0,0,0) // Usage counter register
         },
         "Standby" // Name
-      },
-
-      // Retention state.
-      Package () {
-        1000, // Min Residency (us)
-        950, // Wakeup Latency (us)
-        1, // Flags, set bit0 to 1 to enable this state
-        0, // Arch. Context Lost Flags
-        0, // Residency Counter Frequency
-        0, // Enabled Parent State
-        ResourceTemplate () {
-          // Entry method for the WFI state. See the ARM FFH Specification (ARM DEN 0048).
-          Register (FFixedHW, 0x20, 0, 0x0000000000000000, 3)
-        },
-        ResourceTemplate () {
-          Register (SystemMemory,0,0,0,0) // Residency counter register
-        },
-        ResourceTemplate () {
-          Register (SystemMemory,0,0,0,0) // Usage counter register
-        },
-        "Powerdown" // Name
       },
     })
 }
@@ -102,7 +81,7 @@ Device (CPU1)
     Name (_LPI, Package () {
       0, // Revision
       0, // LevelID
-      2, // Count of packages
+      1, // Count of packages
 
       // Standby / WFI state.
       Package () {
@@ -123,27 +102,6 @@ Device (CPU1)
           Register (SystemMemory,0,0,0,0) // Usage counter register
         },
         "Standby" // Name
-      },
-
-      // Retention state.
-      Package () {
-        1000, // Min Residency (us)
-        950, // Wakeup Latency (us)
-        1, // Flags, set bit0 to 1 to enable this state
-        0, // Arch. Context Lost Flags
-        0, // Residency Counter Frequency
-        0, // Enabled Parent State
-        ResourceTemplate () {
-          // Entry method for the WFI state. See the ARM FFH Specification (ARM DEN 0048).
-          Register (FFixedHW, 0x20, 0, 0x0000000000000000, 3)
-        },
-        ResourceTemplate () {
-          Register (SystemMemory,0,0,0,0) // Residency counter register
-        },
-        ResourceTemplate () {
-          Register (SystemMemory,0,0,0,0) // Usage counter register
-        },
-        "Powerdown" // Name
       },
     })
 }
@@ -162,7 +120,7 @@ Device (CPU2)
     Name (_LPI, Package () {
       0, // Revision
       0, // LevelID
-      2, // Count of packages
+      1, // Count of packages
 
       // Standby / WFI state.
       Package () {
@@ -183,27 +141,6 @@ Device (CPU2)
           Register (SystemMemory,0,0,0,0) // Usage counter register
         },
         "Standby" // Name
-      },
-
-      // Retention state.
-      Package () {
-        1000, // Min Residency (us)
-        950, // Wakeup Latency (us)
-        1, // Flags, set bit0 to 1 to enable this state
-        0, // Arch. Context Lost Flags
-        0, // Residency Counter Frequency
-        0, // Enabled Parent State
-        ResourceTemplate () {
-          // Entry method for the WFI state. See the ARM FFH Specification (ARM DEN 0048).
-          Register (FFixedHW, 0x20, 0, 0x0000000000000000, 3)
-        },
-        ResourceTemplate () {
-          Register (SystemMemory,0,0,0,0) // Residency counter register
-        },
-        ResourceTemplate () {
-          Register (SystemMemory,0,0,0,0) // Usage counter register
-        },
-        "Powerdown" // Name
       },
     })
 }
@@ -222,7 +159,7 @@ Device (CPU3)
     Name (_LPI, Package () {
       0, // Revision
       0, // LevelID
-      2, // Count of packages
+      1, // Count of packages
 
       // Standby / WFI state.
       Package () {
@@ -243,27 +180,6 @@ Device (CPU3)
           Register (SystemMemory,0,0,0,0) // Usage counter register
         },
         "Standby" // Name
-      },
-
-      // Retention state.
-      Package () {
-        1000, // Min Residency (us)
-        950, // Wakeup Latency (us)
-        1, // Flags, set bit0 to 1 to enable this state
-        0, // Arch. Context Lost Flags
-        0, // Residency Counter Frequency
-        0, // Enabled Parent State
-        ResourceTemplate () {
-          // Entry method for the WFI state. See the ARM FFH Specification (ARM DEN 0048).
-          Register (FFixedHW, 0x20, 0, 0x0000000000000000, 3)
-        },
-        ResourceTemplate () {
-          Register (SystemMemory,0,0,0,0) // Residency counter register
-        },
-        ResourceTemplate () {
-          Register (SystemMemory,0,0,0,0) // Usage counter register
-        },
-        "Powerdown" // Name
       },
     })
 }


### PR DESCRIPTION
New PSCI retention idle state doesn't work on iMX8M Mini.  Revert change to Silicon tree and enable only in iMX8M Quad platform tree.