### PR TITLE
Fix path to fTPM binary for ARM64.

### DIFF
--- a/iMX8Pkg/iMX8CommonFdf.inc
+++ b/iMX8Pkg/iMX8CommonFdf.inc
@@ -132,7 +132,7 @@
 
   # fTPM Service TA UUID in UEFI format: bc50d971-d4c9-42c4-82cb-343fb7f37896
   FILE FREEFORM = BC50D971-D4C9-42C4-82CB-343FB7F37896 {
-    SECTION RAW = Microsoft/OpteeClientPkg/Bin/fTpmTa/Arm/Test/bc50d971-d4c9-42c4-82cb-343fb7f37896.ta
+    SECTION RAW = Microsoft/OpteeClientPkg/Bin/fTpmTa/Arm64/Test/bc50d971-d4c9-42c4-82cb-343fb7f37896.ta
   }
 
   # AuthVar Service TA UUID in UEFI format: 2d57c0f7-bddf-48ea-832f-d84a1a219301


### PR DESCRIPTION
When building with TAs included, make searches for the fTPM binary in the wrong path. This change fixes the path.